### PR TITLE
Add area and timing optimization

### DIFF
--- a/fpdiv_scalar/rtl/fpdiv_scalar.sv
+++ b/fpdiv_scalar/rtl/fpdiv_scalar.sv
@@ -3,11 +3,14 @@
 // Author				: HYF
 // How to Contact		: hyf_sysu@qq.com
 // Created Time    		: 2021-12-01 21:23:29
-// Last Modified Time   : 2022-01-02 19:30:20
+// Last Modified Time   : 2022-01-05 10:45:26
 // ========================================================================================================
 // Description	:
 // A Scalar Floating Point Divider based on radix-2 srt algorithm.
-// It supports fp16/32/64. (Maybe add support for bfloat16/tfloat32 in the future ??)
+// It supports fp16/32/64.
+// From now on, this module will not be updated, because it can be completely replaced by "fpdiv_scalar_fast_init.sv".
+// Any further optimization will only be added to "fpdiv_scalar_fast_init.sv".
+// This file is only kept for reference.
 // ========================================================================================================
 // ========================================================================================================
 // Copyright (C) 2021, HYF. All Rights Reserved.


### PR DESCRIPTION
1. 对frac_rem_sum/carry_d的逻辑进行优化，减小关键路径的复杂度

2. 输入数据是denormal的fp64数字时，使用frac_divisor[11:0]来存储pre_0中算出的需要左移的位数，省下12-bit的reg

3. 使用quo_iter_q/quo_m1_iter_q空闲的2个bit来存储post_0中选出的要用来计算sticky_bit的rem, 同时将frac_divisor_q的宽度由54减小到了52

综上所述一共减少了14-bit的reg, 对面积有些许优化