### PR TITLE
Fix some details, make it can be simulated by verilator

### DIFF
--- a/int_div_radix_4_v1/rtl/int_div_radix_4_v1.sv
+++ b/int_div_radix_4_v1/rtl/int_div_radix_4_v1.sv
@@ -292,7 +292,7 @@ end
 // PRE_PROCESS_1: r_shift the dividend for "dividend_too_small/divisor_is_zero".
 // POST_PROCESS_1: If "dividend_too_small/divisor_is_zero", we should not do any r_shift. Because we have already put dividend into the correct position
 // in PRE_PROCESS_1.
-assign post_r_shift_num = fsm_q[FSM_PRE_1_BIT] ? dividend_lzc_q : ((dividend_too_small_q | divisor_is_zero) ? {(LZC_WIDTH){1'b0}} : divisor_lzc_q);
+assign post_r_shift_num = fsm_q[FSM_PRE_1_BIT] ? dividend_lzc_q[LZC_WIDTH-1:0] : ((dividend_too_small_q | divisor_is_zero) ? {(LZC_WIDTH){1'b0}} : divisor_lzc_q[LZC_WIDTH-1:0]);
 assign post_r_shift_data_in = fsm_q[FSM_PRE_1_BIT] ? dividend_abs_q[WIDTH-1:0] : pre_shifted_rem[WIDTH-1:0];
 assign post_r_shift_extend_msb = fsm_q[FSM_POST_1_BIT] & rem_sign_q & pre_shifted_rem[WIDTH];
 

--- a/int_div_radix_4_v1/rtl/lzc.sv
+++ b/int_div_radix_4_v1/rtl/lzc.sv
@@ -56,8 +56,8 @@ module lzc #(
     // pragma translate_on
 
     logic [WIDTH-1:0][NumLevels-1:0] index_lut;
-    logic [2**NumLevels-1:0] sel_nodes;
-    logic [2**NumLevels-1:0][NumLevels-1:0] index_nodes;
+    logic [2**NumLevels-1:0] sel_nodes /*verilator split_var*/;
+    logic [2**NumLevels-1:0][NumLevels-1:0] index_nodes /*verilator split_var*/;
 
     logic [WIDTH-1:0] in_tmp;
 


### PR DESCRIPTION
There is a bit-width error on the main module, and a peculiar error which can be repaired simply by adding some comment statements that can have an effect on verilator's compiler.

Now we can use verilator to simulator these modules directly